### PR TITLE
prevent column animation to break layouts on svelte kit page change

### DIFF
--- a/src/lib/components/Column/Column.svelte
+++ b/src/lib/components/Column/Column.svelte
@@ -50,7 +50,7 @@
 
 </script>
 
-<div class="column {theme}" style:background="{secondary}" in:fly="{{y:-200, duration:500}}" out:fly="{{y:200, duration:500}}">
+<div class="column {theme}" style:background="{secondary}" in:fly|local="{{y:-200, duration:500}}" out:fly|local="{{y:200, duration:500}}">
     <div class="title" >
         {#if bool_show_options}
             <button style:color="{fontPrimary}" class="button-title" id="title-column{index_col}" on:click={modifyColumnHandler}>{title}</button>


### PR DESCRIPTION
fixes #42 by declaring transitions as `local` 

https://svelte.dev/docs#template-syntax-element-directives-transition-fn
 