### PR TITLE
Remove node-sass from dependencies and add sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"node-sass": "^6.0.1",
+		"sass": "^1.55.0",
 		"svelte2tsx": "^0.4.14"
 	}
 }


### PR DESCRIPTION
node-sass is deprecated since they moved over to dart and sass is the up-to-date implementation.