### PR TITLE
chore: Update README: Usage/installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,18 @@
 
 <img src="https://raw.githubusercontent.com/V-Py/svelte-kanban/master/static/kanbancapture.PNG" alt="Svelte Kanban">
 <slot />
+
 ## Installation
 
 ```sh
-npm i svelte-kanban
-npm i --save-dev svelte svelte-preprocess sass
+npm i --save svelte-kanban
 ```
 
 This is beyond the scope of this guide, but your build system (Vite, ESBuild, etc.) should use the `svelte-preprocess` plugin:
+
+```sh
+npm i --save-dev svelte-preprocess sass
+```
 
 ```js
   preprocess: sveltePreprocess()

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 **A simple Svelte Kanban made in pure CSS**
 
 <img src="https://raw.githubusercontent.com/V-Py/svelte-kanban/master/static/kanbancapture.PNG" alt="Svelte Kanban">
+<slot />
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,22 +19,12 @@
 **A simple Svelte Kanban made in pure CSS**
 
 <img src="https://raw.githubusercontent.com/V-Py/svelte-kanban/master/static/kanbancapture.PNG" alt="Svelte Kanban">
-<slot />
 
 ## Installation
 
 ```sh
 npm i --save svelte-kanban
-```
-
-This is beyond the scope of this guide, but your build system (Vite, ESBuild, etc.) should use the `svelte-preprocess` plugin:
-
-```sh
-npm i --save-dev svelte-preprocess sass
-```
-
-```js
-  preprocess: sveltePreprocess()
+npm i --save-dev sass
 ```
 
 ## Usage


### PR DESCRIPTION
@V-Py Why does the README have a `<slot />` element? It's not hurting anything but I am curious. Is this file used (or planned to be) as a svelte component somehow?